### PR TITLE
Fix BLE pairing for newer bluez lib

### DIFF
--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -185,11 +185,11 @@ gboolean BluezEndpoint::BluezCharacteristicAcquireNotify(BluezGattCharacteristic
     }
 
     conn->SetupNotifyHandler(fds[0], isAdditionalAdvertising);
-    bluez_gatt_characteristic1_set_notify_acquired(aChar, TRUE);
+    // bluez_gatt_characteristic1_set_notify_acquired(aChar, TRUE);
     conn->SetNotifyAcquired(true);
 
     GUnixFDList * fdList = g_unix_fd_list_new_from_array(&fds[1], 1);
-    bluez_gatt_characteristic1_complete_acquire_notify(aChar, aInvocation, fdList, g_variant_new_handle(0), conn->GetMTU());
+    // bluez_gatt_characteristic1_complete_acquire_notify(aChar, aInvocation, fdList, g_variant_new_handle(0), conn->GetMTU());
     g_object_unref(fdList);
 
     BLEManagerImpl::HandleTXCharCCCDWrite(conn);


### PR DESCRIPTION
BLE pairing fails on newer BlueZ library versions: https://github.com/project-chip/connectedhomeip/issues/37359

This PR contains a quick-fix, and nice to have if we need to update the library (or use another laptop as a matter device)